### PR TITLE
feat/- remove ticket section from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,3 @@ what has to be tested?
 ## Screenshots
 
 <!-- Would including screenshots be helpful to the reviewer? -->
-
-## Tickets
-
-- Closes/Fixes: <!-- add link to Click-Up ticket -->


### PR DESCRIPTION
# Remove Tickets Section from template


## Description

with new pr guidelines PRs should always have the Ticket ID in the name and therefore we dont need the ticket section in the guidelines anymore


## Motivation / Context

it was bothering me

## Testing Instructions / How This Has Been Tested

-

## Checklist

- [x] PR documented
- [ ] Code Review done according to [our guidelines](https://github.com/LX-media/lx-shared/blob/main/code-review-guideline.md)
- [ ] Manual/local testing

## Screenshots
-


